### PR TITLE
Add GitHub Actions workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Firebase から GitHub Pages へのデプロイ移行のため、GitHub Actions ワークフローを追加
- `main` ブランチへのプッシュ時に `docs/` ディレクトリを自動デプロイ
- GitHub UI からの手動実行 (`workflow_dispatch`) にも対応

## 設定手順

マージ後、GitHub リポジトリの **Settings → Pages → Source** を `GitHub Actions` に変更してください。

## Test plan

- [x] PR をマージする
- [x] Settings → Pages → Source を `GitHub Actions` に設定する
- [ ] `main` にプッシュしてワークフローが正常に実行されることを確認する
- [ ] デプロイ後に https://sgtao.github.io/aio-typing/ が正常に表示されることを確認する

https://claude.ai/code/session_01V1AXdRk9StA6PhF41uzr5t

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1AXdRk9StA6PhF41uzr5t)_